### PR TITLE
fix: Download necessary NLTK data for the tokenizer

### DIFF
--- a/docling_eval/cli/main.py
+++ b/docling_eval/cli/main.py
@@ -91,6 +91,7 @@ def log_and_save_stats(
     log.info(content)
     with open(log_filename, "w") as fd:
         fd.write(content)
+        log.info("Saving statistics report to %s", log_filename)
     stats.save_histogram(figname=fig_filename, name=metric)
 
     return log_filename, fig_filename
@@ -221,7 +222,7 @@ def visualise(
 
         # Save layout statistics for mAP
         log_filename, _ = log_and_save_stats(
-            odir, benchmark, modality, "mAP[0.5_0.95]", layout_evaluation.mAP_stats
+            odir, benchmark, modality, "mAP_0.5_0.95", layout_evaluation.mAP_stats
         )
 
         # Append to layout statistics the mAP classes

--- a/docling_eval/evaluators/markdown_text_evaluator.py
+++ b/docling_eval/evaluators/markdown_text_evaluator.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+import nltk
 from datasets import load_dataset
 from docling_core.types.doc.base import ImageRefMode
 from docling_core.types.doc.document import DoclingDocument
@@ -31,7 +32,8 @@ class DatasetMarkdownEvaluation(BaseModel):
 
 class MarkdownTextEvaluator:
     def __init__(self):
-        pass
+        # Download the necessary NLTK data for the tokenizer
+        nltk.download("punkt_tab", quiet=True)
 
     def __call__(self, ds_path: Path, split: str = "test") -> DatasetMarkdownEvaluation:
         parquet_files = str(ds_path / split / "*.parquet")

--- a/docling_eval/evaluators/stats.py
+++ b/docling_eval/evaluators/stats.py
@@ -69,7 +69,7 @@ class DatasetStatistics(BaseModel):
             f"{name} (mean: {self.mean:.2f}, median: {self.median:.2f}, std: {self.std:.2f}, total: {self.total})"
         )
 
-        logging.info(f"saving figure to {figname}")
+        logging.info(f"Saving figure to {figname}")
         plt.savefig(figname)
 
 


### PR DESCRIPTION
This is a fix to ensure that NLTK has downloaded the necessary data for the tokenizer.