### PR TITLE
feat: Extend CLI to allow loading the full split. Add the MODALITIES field in constants.

### DIFF
--- a/docling_eval/benchmarks/constants.py
+++ b/docling_eval/benchmarks/constants.py
@@ -26,6 +26,8 @@ class BenchMarkColumns(str, Enum):
     MIMETYPE = "mimetype"
     TIMINGS = "timings"
 
+    MODALITIES = "modalities"
+
 
 class EvaluationModality(str, Enum):
     END2END = "end-to-end"

--- a/docling_eval/benchmarks/doclaynet_v1/create.py
+++ b/docling_eval/benchmarks/doclaynet_v1/create.py
@@ -167,14 +167,19 @@ def create_dlnv1_e2e_dataset(
     split: str,
     output_dir: Path,
     do_viz: bool = False,
-    max_items: int = -1,
+    max_items: int = -1,  # If -1 take the whole split
 ):
+    print(f"Downloading split: {split}")
+
     ds = load_dataset(name, split=split)
     converter = create_converter(page_image_scale=1.0)
 
     if do_viz:
         viz_dir = output_dir / "visualizations"
         os.makedirs(viz_dir, exist_ok=True)
+
+    if max_items == -1:
+        max_items = len(ds)
 
     test_dir = output_dir / split
     os.makedirs(test_dir, exist_ok=True)

--- a/docling_eval/benchmarks/tableformer_huggingface_otsl/create.py
+++ b/docling_eval/benchmarks/tableformer_huggingface_otsl/create.py
@@ -94,7 +94,7 @@ def create_huggingface_otsl_tableformer_dataset(
     max_records: int = 1000,
     split: str = "test",
     do_viz: bool = False,
-    max_items: int = -1,
+    max_items: int = -1,  # If -1, then take the whole split
     mode: TableFormerMode = TableFormerMode.ACCURATE,
     artifacts_path: Optional[Path] = None,
 ):

--- a/docling_eval/cli/main.py
+++ b/docling_eval/cli/main.py
@@ -125,7 +125,10 @@ def create(
         ):
             # No support for max_items
             create_dpbench_e2e_dataset(
-                dpbench_dir=idir, output_dir=odir, image_scale=image_scale
+                dpbench_dir=idir,
+                output_dir=odir,
+                image_scale=image_scale,
+                do_viz=True,
             )
 
         elif modality == EvaluationModality.TABLEFORMER:
@@ -201,11 +204,6 @@ def create(
             log.error(f"{modality} is not yet implemented for {benchmark}")
 
     elif benchmark == BenchMarkNames.DOCLAYNETV1:
-        if idir is None:
-            log.error(
-                "The input dir for %s must be provided", BenchMarkNames.DOCLAYNETV1
-            )
-        assert idir is not None
         if modality == EvaluationModality.LAYOUT:
             create_dlnv1_e2e_dataset(
                 name="ds4sd/DocLayNet-v1.2",

--- a/docs/examples/benchmark_doclaynet_v1.py
+++ b/docs/examples/benchmark_doclaynet_v1.py
@@ -51,6 +51,22 @@ def main():
             odir=odir_lay,
         )
 
+        # Markdown text
+        log.info("Evaluate the markdown text for the DocLayNet dataset")
+        evaluate(
+            modality=EvaluationModality.MARKDOWN_TEXT,
+            benchmark=BenchMarkNames.DOCLAYNETV1,
+            idir=odir_lay,
+            odir=odir_lay,
+        )
+        log.info("Visualize the markdown text for the DocLayNet dataset")
+        visualise(
+            modality=EvaluationModality.MARKDOWN_TEXT,
+            benchmark=BenchMarkNames.DOCLAYNETV1,
+            idir=odir_lay,
+            odir=odir_lay,
+        )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Allow to use the full dataset split when passing the parameter `-n  -1` in CLI.
- Introduce the constant `BenchMarkColumns.MODALITIES`.