### PR TITLE
Update PubTabNet_benchmarks.md

### DIFF
--- a/docs/PubTabNet_benchmarks.md
+++ b/docs/PubTabNet_benchmarks.md
@@ -4,7 +4,7 @@ Create PubTabNet evaluation datasets. This downloads from Huggingface the [PubTa
 
 ```sh
 # Make the ground-truth
-docling_eval create-gt --benchmark PubTabNet --output-dir ./benchmarks/PubTabNet/ 
+docling_eval create-gt --benchmark PubTabNet --split val --output-dir ./benchmarks/PubTabNet/ 
 
 # Make predictions for tables.
 docling_eval create-eval \

--- a/docs/PubTabNet_benchmarks.md
+++ b/docs/PubTabNet_benchmarks.md
@@ -8,7 +8,7 @@ docling_eval create-gt --benchmark PubTabNet --split val --output-dir ./benchmar
 
 # Make predictions for tables.
 docling_eval create-eval \
-  --benchmark DPBench \
+  --benchmark PubTabNet \
   --output-dir ./benchmarks/PubTabNet/ \
   --end-index 1000 \
   --prediction-provider tableformer # use tableformer predictions only

--- a/docs/PubTabNet_benchmarks.md
+++ b/docs/PubTabNet_benchmarks.md
@@ -9,6 +9,7 @@ docling_eval create-gt --benchmark PubTabNet --split val --output-dir ./benchmar
 # Make predictions for tables.
 docling_eval create-eval \
   --benchmark PubTabNet \
+  --split val \
   --output-dir ./benchmarks/PubTabNet/ \
   --end-index 1000 \
   --prediction-provider tableformer # use tableformer predictions only


### PR DESCRIPTION
With the default `--split test`, the create-gt method throws an exception `Error creating dataset builder: Unknown split "test". Should be one of ['train', 'val'].`. Indeed, https://huggingface.co/datasets/ds4sd/PubTabNet_OTSL only has train and val splits. Given this, I believe using the `val` split is more suitable for this dataset.