### PR TITLE
fix: handle unsupported END2END evaluation and fix variable name in OCR

### DIFF
--- a/docling_eval/cli/main.py
+++ b/docling_eval/cli/main.py
@@ -417,6 +417,7 @@ def evaluate(
 
     if modality == EvaluationModality.END2END:
         _log.error("END2END evaluation not supported. ")
+        return None
 
     elif modality == EvaluationModality.LAYOUT:
         layout_evaluator = LayoutEvaluator()
@@ -440,13 +441,13 @@ def evaluate(
 
     elif modality == EvaluationModality.OCR:
         ocr_evaluator = OCREvaluator()
-        ocr_evaluation = ocr_evaluator(
+        evaluation = ocr_evaluator(
             idir,
             split=split,
         )
 
         with open(save_fn, "w") as fd:
-            json.dump(ocr_evaluation.model_dump(), fd, indent=2, sort_keys=True)
+            json.dump(evaluation.model_dump(), fd, indent=2, sort_keys=True)
 
     elif modality == EvaluationModality.READING_ORDER:
         readingorder_evaluator = ReadingOrderEvaluator()

--- a/docling_eval/cli/main.py
+++ b/docling_eval/cli/main.py
@@ -441,7 +441,7 @@ def evaluate(
 
     elif modality == EvaluationModality.OCR:
         ocr_evaluator = OCREvaluator()
-        evaluation = ocr_evaluator(
+        evaluation = ocr_evaluator(  # type: ignore
             idir,
             split=split,
         )


### PR DESCRIPTION
Noticed the bug when running the tests locally:
```
TestOcr::test_ocr[amazon-PixparseIdl] - UnboundLocalError: cannot access local variable 'evaluation' where it is not associated with a value
```