### PR TITLE
Update boto3 client to use the credentials

### DIFF
--- a/docling_eval/prediction_providers/aws_prediction_provider.py
+++ b/docling_eval/prediction_providers/aws_prediction_provider.py
@@ -74,7 +74,12 @@ class AWSTextractPredictionProvider(BasePredictionProvider):
 
         region_name = os.getenv("AWS_REGION", "us-east-1")
 
-        self.textract_client = boto3.client("textract", aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key, region_name=region_name)
+        self.textract_client = boto3.client(
+            "textract",
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            region_name=region_name,
+        )
 
     def extract_bbox_from_geometry(self, geometry):
         """Helper function to extract bbox coordinates from AWS Textract geometry data."""

--- a/docling_eval/prediction_providers/aws_prediction_provider.py
+++ b/docling_eval/prediction_providers/aws_prediction_provider.py
@@ -74,7 +74,7 @@ class AWSTextractPredictionProvider(BasePredictionProvider):
 
         region_name = os.getenv("AWS_REGION", "us-east-1")
 
-        self.textract_client = boto3.client("textract", region_name=region_name)
+        self.textract_client = boto3.client("textract", aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key, region_name=region_name)
 
     def extract_bbox_from_geometry(self, geometry):
         """Helper function to extract bbox coordinates from AWS Textract geometry data."""


### PR DESCRIPTION
Update boto3 client to use the credentials directly instead of using the credentials stored in the environment variables.