### PR TITLE
feat: Add Table structure evaluations for TEDS

### DIFF
--- a/docling_eval/evaluators/table_evaluator.py
+++ b/docling_eval/evaluators/table_evaluator.py
@@ -32,7 +32,7 @@ class TableEvaluation(UnitEvaluation):
     table_id: int = -1
     TEDS: float
     is_complex: bool = False
-    is_structure_only: bool = False
+    structure_only_evaluation: bool = False
 
     true_ncols: int = -1
     pred_ncols: int = -1
@@ -298,7 +298,7 @@ class TableEvaluator(BaseEvaluator):
                     pred_ncols=pred_table.data.num_cols,
                     true_nrows=true_table.data.num_rows,
                     pred_nrows=pred_table.data.num_rows,
-                    is_structure_only=structure_only,
+                    structure_only_evaluation=structure_only,
                 )
                 table_evaluations.append(table_evaluation)
             except Exception:

--- a/docling_eval/evaluators/table_evaluator.py
+++ b/docling_eval/evaluators/table_evaluator.py
@@ -43,6 +43,7 @@ class TableEvaluation(UnitEvaluation):
 
 class DatasetTableEvaluation(DatasetEvaluation):
     evaluations: List[TableEvaluation]
+    structure_only_evaluations: Optional[List[TableEvaluation]] = None
 
     TEDS: DatasetStatistics
     TEDS_struct: DatasetStatistics
@@ -228,7 +229,8 @@ class TableEvaluator(BaseEvaluator):
         dataset_evaluation = DatasetTableEvaluation(
             evaluated_samples=len(table_evaluations),
             rejected_samples=rejected_samples,
-            evaluations=table_evaluations + table_struct_evaluations,
+            evaluations=table_evaluations,
+            structure_only_evaluations=table_struct_evaluations,
             TEDS=compute_stats(teds_all),
             TEDS_struct=compute_stats(teds_struct),
             TEDS_simple=compute_stats(teds_simple),

--- a/docling_eval/evaluators/table_evaluator.py
+++ b/docling_eval/evaluators/table_evaluator.py
@@ -43,7 +43,7 @@ class TableEvaluation(UnitEvaluation):
 
 class DatasetTableEvaluation(DatasetEvaluation):
     evaluations: List[TableEvaluation]
-    structure_only_evaluations: Optional[List[TableEvaluation]] = None
+    table_structure_evaluations: List[TableEvaluation]
 
     TEDS: DatasetStatistics
     TEDS_struct: DatasetStatistics
@@ -230,7 +230,7 @@ class TableEvaluator(BaseEvaluator):
             evaluated_samples=len(table_evaluations),
             rejected_samples=rejected_samples,
             evaluations=table_evaluations,
-            structure_only_evaluations=table_struct_evaluations,
+            table_structure_evaluations=table_struct_evaluations,
             TEDS=compute_stats(teds_all),
             TEDS_struct=compute_stats(teds_struct),
             TEDS_simple=compute_stats(teds_simple),

--- a/docling_eval/evaluators/table_evaluator.py
+++ b/docling_eval/evaluators/table_evaluator.py
@@ -32,6 +32,7 @@ class TableEvaluation(UnitEvaluation):
     table_id: int = -1
     TEDS: float
     is_complex: bool = False
+    is_structure_only: bool = False
 
     true_ncols: int = -1
     pred_ncols: int = -1
@@ -227,7 +228,7 @@ class TableEvaluator(BaseEvaluator):
         dataset_evaluation = DatasetTableEvaluation(
             evaluated_samples=len(table_evaluations),
             rejected_samples=rejected_samples,
-            evaluations=table_evaluations,
+            evaluations=table_evaluations + table_struct_evaluations,
             TEDS=compute_stats(teds_all),
             TEDS_struct=compute_stats(teds_struct),
             TEDS_simple=compute_stats(teds_simple),
@@ -297,6 +298,7 @@ class TableEvaluator(BaseEvaluator):
                     pred_ncols=pred_table.data.num_cols,
                     true_nrows=true_table.data.num_rows,
                     pred_nrows=pred_table.data.num_rows,
+                    is_structure_only=structure_only,
                 )
                 table_evaluations.append(table_evaluation)
             except Exception:


### PR DESCRIPTION
As of now, the "evaluations" hold independent results of tables for TEDS only. Extend it to include the values of TEDS_struct evaluations as well.

1. TableEvaluation class is extended to have another flag "is_structure_only" to distinguish between TEDS & TEDS_struct => The existing field "TEDS" will be the score as-is.
2. Append the table_struct_evaluations as well into the result.