### PR TITLE
Divekarsc/azure converter fix

### DIFF
--- a/tests/test_tables_azure.py
+++ b/tests/test_tables_azure.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 import pytest
+from dotenv import load_dotenv
 
 from docling_eval.cli.main import evaluate, visualize
 from docling_eval.datamodels.types import BenchMarkNames, EvaluationModality
@@ -20,6 +21,8 @@ logging.getLogger("PIL").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 logging.getLogger("filelock").setLevel(logging.WARNING)
+
+load_dotenv()
 
 
 @pytest.mark.skipif(
@@ -55,6 +58,44 @@ def test_run_fintabnet_builder():
     visualize(
         modality=EvaluationModality.TABLE_STRUCTURE,
         benchmark=BenchMarkNames.FINTABNET,
+        idir=target_path / "eval_dataset",
+        odir=target_path / "evaluations" / EvaluationModality.TABLE_STRUCTURE.value,
+    )
+
+
+@pytest.mark.skipif(
+    IS_CI, reason="Skipping test in CI because the dataset is too heavy."
+)
+def test_run_pubtabnet_builder():
+    target_path = Path(f"./scratch/{BenchMarkNames.PUBTABNET.value}_azure/")
+    azure_provider = AzureDocIntelligencePredictionProvider(
+        do_visualization=True, ignore_missing_predictions=True
+    )
+
+    dataset = FintabNetDatasetBuilder(
+        target=target_path / "gt_dataset",
+        end_index=5,
+    )
+
+    # dataset.retrieve_input_dataset()  # fetches the source dataset from HF
+    dataset.save_to_disk()  # does all the job of iterating the dataset, making GT+prediction records, and saving them in shards as parquet.
+
+    azure_provider.create_prediction_dataset(
+        name=dataset.name,
+        gt_dataset_dir=target_path / "gt_dataset",
+        target_dataset_dir=target_path / "eval_dataset",
+    )
+
+    evaluate(
+        modality=EvaluationModality.TABLE_STRUCTURE,
+        benchmark=BenchMarkNames.PUBTABNET,
+        idir=target_path / "eval_dataset",
+        odir=target_path / "evaluations" / EvaluationModality.TABLE_STRUCTURE.value,
+    )
+
+    visualize(
+        modality=EvaluationModality.TABLE_STRUCTURE,
+        benchmark=BenchMarkNames.PUBTABNET,
         idir=target_path / "eval_dataset",
         odir=target_path / "evaluations" / EvaluationModality.TABLE_STRUCTURE.value,
     )

--- a/tests/test_tables_azure.py
+++ b/tests/test_tables_azure.py
@@ -7,8 +7,11 @@ from dotenv import load_dotenv
 
 from docling_eval.cli.main import evaluate, visualize
 from docling_eval.datamodels.types import BenchMarkNames, EvaluationModality
+from docling_eval.dataset_builders.dpbench_builder import DPBenchDatasetBuilder
 from docling_eval.dataset_builders.otsl_table_dataset_builder import (
-    FintabNetDatasetBuilder, PubTabNetDatasetBuilder,
+    FintabNetDatasetBuilder,
+    PubTables1MDatasetBuilder,
+    PubTabNetDatasetBuilder,
 )
 from docling_eval.prediction_providers.azure_prediction_provider import (
     AzureDocIntelligencePredictionProvider,
@@ -96,6 +99,81 @@ def test_run_pubtabnet_builder():
     visualize(
         modality=EvaluationModality.TABLE_STRUCTURE,
         benchmark=BenchMarkNames.PUBTABNET,
+        idir=target_path / "eval_dataset",
+        odir=target_path / "evaluations" / EvaluationModality.TABLE_STRUCTURE.value,
+    )
+
+
+@pytest.mark.skipif(
+    IS_CI, reason="Skipping test in CI because the dataset is too heavy."
+)
+def test_run_dpbench_builder():
+    target_path = Path(f"./scratch/{BenchMarkNames.DPBENCH.value}_azure/")
+    azure_provider = AzureDocIntelligencePredictionProvider(
+        do_visualization=True, ignore_missing_predictions=True
+    )
+
+    dataset = DPBenchDatasetBuilder(
+        target=target_path / "gt_dataset",
+        begin_index=186,
+        end_index=201,
+    )
+
+    dataset.retrieve_input_dataset()  # fetches the source dataset from HF
+    dataset.save_to_disk()  # does all the job of iterating the dataset, making GT+prediction records, and saving them in shards as parquet.
+
+    azure_provider.create_prediction_dataset(
+        name=dataset.name,
+        gt_dataset_dir=target_path / "gt_dataset",
+        target_dataset_dir=target_path / "eval_dataset",
+    )
+
+    evaluate(
+        modality=EvaluationModality.TABLE_STRUCTURE,
+        benchmark=BenchMarkNames.DPBENCH,
+        idir=target_path / "eval_dataset",
+        odir=target_path / "evaluations" / EvaluationModality.TABLE_STRUCTURE.value,
+    )
+
+    visualize(
+        modality=EvaluationModality.TABLE_STRUCTURE,
+        benchmark=BenchMarkNames.DPBENCH,
+        idir=target_path / "eval_dataset",
+        odir=target_path / "evaluations" / EvaluationModality.TABLE_STRUCTURE.value,
+    )
+
+
+@pytest.mark.skipif(
+    IS_CI, reason="Skipping test in CI because the dataset is too heavy."
+)
+def test_run_pub1m_builder():
+    target_path = Path(f"./scratch/{BenchMarkNames.PUB1M.value}_azure/")
+    azure_provider = AzureDocIntelligencePredictionProvider(
+        do_visualization=True, ignore_missing_predictions=True
+    )
+
+    dataset = PubTables1MDatasetBuilder(
+        target=target_path / "gt_dataset",
+        end_index=15,
+    )
+    dataset.save_to_disk()  # does all the job of iterating the dataset, making GT+prediction records, and saving them in shards as parquet.
+
+    azure_provider.create_prediction_dataset(
+        name=dataset.name,
+        gt_dataset_dir=target_path / "gt_dataset",
+        target_dataset_dir=target_path / "eval_dataset",
+    )
+
+    evaluate(
+        modality=EvaluationModality.TABLE_STRUCTURE,
+        benchmark=BenchMarkNames.PUB1M,
+        idir=target_path / "eval_dataset",
+        odir=target_path / "evaluations" / EvaluationModality.TABLE_STRUCTURE.value,
+    )
+
+    visualize(
+        modality=EvaluationModality.TABLE_STRUCTURE,
+        benchmark=BenchMarkNames.PUB1M,
         idir=target_path / "eval_dataset",
         odir=target_path / "evaluations" / EvaluationModality.TABLE_STRUCTURE.value,
     )

--- a/tests/test_tables_azure.py
+++ b/tests/test_tables_azure.py
@@ -39,7 +39,7 @@ def test_run_fintabnet_builder():
 
     dataset = FintabNetDatasetBuilder(
         target=target_path / "gt_dataset",
-        end_index=5,
+        end_index=15,
     )
 
     # dataset.retrieve_input_dataset()  # fetches the source dataset from HF

--- a/tests/test_tables_azure.py
+++ b/tests/test_tables_azure.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 from docling_eval.cli.main import evaluate, visualize
 from docling_eval.datamodels.types import BenchMarkNames, EvaluationModality
 from docling_eval.dataset_builders.otsl_table_dataset_builder import (
-    FintabNetDatasetBuilder,
+    FintabNetDatasetBuilder, PubTabNetDatasetBuilder,
 )
 from docling_eval.prediction_providers.azure_prediction_provider import (
     AzureDocIntelligencePredictionProvider,
@@ -72,9 +72,9 @@ def test_run_pubtabnet_builder():
         do_visualization=True, ignore_missing_predictions=True
     )
 
-    dataset = FintabNetDatasetBuilder(
+    dataset = PubTabNetDatasetBuilder(
         target=target_path / "gt_dataset",
-        end_index=5,
+        end_index=15,
     )
 
     # dataset.retrieve_input_dataset()  # fetches the source dataset from HF


### PR DESCRIPTION
The original implementation of Azure prediction provider for tables was based on Azure API version 2023-07-31. Since then Azure has come up with API version 2024-11-30, which is the latest version. For our evaluation purposes,  we should be comparing against the latest version instead of an almost 2 years old version. This PR is to update the prediction provider to read from the current schema of tables.

Open question:
Azure API returns coordinates in pixels for image input and in inches for PDF input. Do we need to convert PDF dimensions into pixel coordinates before setting them in `DoclingDocument`? Or can `DoclingDocument` handle both types of coordinates for evaluation/visualization purposes?