### PR TITLE
Add functionality to merge cells in Google OCR prediction

### DIFF
--- a/docling_eval/prediction_providers/google_prediction_provider.py
+++ b/docling_eval/prediction_providers/google_prediction_provider.py
@@ -38,7 +38,7 @@ from docling_eval.datamodels.types import PredictionFormats, PredictionProviderT
 from docling_eval.prediction_providers.base_prediction_provider import (
     BasePredictionProvider,
 )
-from docling_eval.utils.utils import from_pil_to_base64uri
+from docling_eval.utils.utils import from_pil_to_base64uri, global_merge
 
 _log = logging.getLogger(__name__)
 
@@ -384,6 +384,7 @@ class GoogleDocAIPredictionProvider(BasePredictionProvider):
                 pred_doc, pred_segmented_pages = self.convert_google_output_to_docling(
                     result_json, record
                 )
+                pred_segmented_pages = global_merge(pred_segmented_pages)
             else:
                 raise RuntimeError(
                     f"Unsupported mime type: {record.mime_type}. GoogleDocAIPredictionProvider supports 'application/pdf' and 'image/png'"


### PR DESCRIPTION
The F1 scores regressed on Google for OCR as compared to the previous evaluations and upon investigating we found out that we had a functionality to merge cells before running the evaluations for Google OCR. Here's the overview of what the new code does:

- Join words that were incorrectly split during scanning
- Reconnect special characters (hyphens, apostrophes, periods) with their words
- Fix spacing issues in numbers, dates, and punctuation
- Makes the text easier to read and process by putting split words back together
