### PR TITLE
feat: Extend the FileProvider and the CLI to accept parameters that control the source of the  prediction images

### DIFF
--- a/docling_eval/cli/main.py
+++ b/docling_eval/cli/main.py
@@ -233,6 +233,8 @@ def get_prediction_provider(
     *,
     file_source_path: Optional[Path] = None,
     file_prediction_format: Optional[PredictionFormats] = None,
+    file_use_ground_truth_images: bool = True,
+    file_images_path: Optional[Path] = None,
     do_visualization: bool = True,
     do_table_structure: bool = True,
     artifacts_path: Optional[Path] = None,
@@ -407,7 +409,8 @@ def get_prediction_provider(
             do_visualization=do_visualization,
             ignore_missing_predictions=True,
             ignore_missing_files=True,
-            use_ground_truth_page_images=False,
+            use_ground_truth_page_images=file_use_ground_truth_images,
+            prediction_images_path=file_images_path,
         )
 
     else:
@@ -917,7 +920,19 @@ def create_eval(
     file_source_path: Annotated[
         Optional[Path],
         typer.Option(
-            help="Source path for File provider (required if using FILE provider)"
+            help="Source path for prediction files (required if using FILE provider)"
+        ),
+    ] = None,
+    file_use_ground_truth_images: Annotated[
+        bool,
+        typer.Option(
+            help="Use the GT images to construct the prediction dataset (if using FILE provider)"
+        ),
+    ] = True,
+    file_images_path: Annotated[
+        Optional[Path],
+        typer.Option(
+            help="Source path for the prediction images (if using FILE provider)"
         ),
     ] = None,
     artifacts_path: Annotated[
@@ -962,6 +977,8 @@ def create_eval(
             provider_type=prediction_provider,
             file_source_path=file_source_path,
             file_prediction_format=file_format,
+            file_use_ground_truth_images=file_use_ground_truth_images,
+            file_images_path=file_images_path,
             artifacts_path=artifacts_path,
             do_visualization=do_visualization,
             image_scale_factor=image_scale_factor,

--- a/docling_eval/prediction_providers/file_provider.py
+++ b/docling_eval/prediction_providers/file_provider.py
@@ -182,7 +182,7 @@ class FilePredictionProvider(BasePredictionProvider):
             with open(doctags_fn, "r") as fd:
                 doctags = fd.read()
 
-            page_image = None
+            page_image: Optional[Image.Image] = None
 
             # Try to get an image file for the predictions:
             # 1. Check the pred_images_path.
@@ -190,14 +190,18 @@ class FilePredictionProvider(BasePredictionProvider):
             # 3. Look inside the same dir as the doctag files.
             if self._prediction_images_path:
                 page_image_fn = self._prediction_images_path / f"{record.doc_id}.png"
+                if page_image_fn.is_file():
+                    page_image = Image.open(page_image_fn)
+                else:
+                    _log.warning("Failed to load pred image: %s", page_image_fn)
             elif self._use_ground_truth_page_images:
                 page_image = record.ground_truth_page_images[0]
             else:
                 page_image_fn = self._prediction_source_path / f"{record.doc_id}.png"
-            if page_image_fn.is_file():
-                page_image = Image.open(page_image_fn)
-            else:
-                _log.warning("Failed to load pred image: %s", page_image_fn)
+                if page_image_fn.is_file():
+                    page_image = Image.open(page_image_fn)
+                else:
+                    _log.warning("Failed to load pred image: %s", page_image_fn)
 
             # Build DoclingDocument
             doctags_page = DocTagsPage(tokens=doctags, image=page_image)

--- a/docling_eval/prediction_providers/file_provider.py
+++ b/docling_eval/prediction_providers/file_provider.py
@@ -48,7 +48,8 @@ class FilePredictionProvider(BasePredictionProvider):
         ignore_missing_predictions: bool = True,
         true_labels: Optional[Set[DocItemLabel]] = None,
         pred_labels: Optional[Set[DocItemLabel]] = None,
-        use_ground_truth_page_images: bool = False,
+        use_ground_truth_page_images: bool = True,
+        prediction_images_path: Optional[Path] = None,
     ):
         """
         Initialize the file prediction provider.
@@ -61,6 +62,8 @@ class FilePredictionProvider(BasePredictionProvider):
             ignore_missing_predictions: Whether to ignore missing predictions
             true_labels: Set of DocItemLabel to use for ground truth visualization
             pred_labels: Set of DocItemLabel to use for prediction visualization
+            use_ground_truth_page_images: Flag to use the GT page images for the predictions.
+            prediction_images_path: Directory to load the prediction images
         """
         super().__init__(
             do_visualization=do_visualization,
@@ -69,6 +72,7 @@ class FilePredictionProvider(BasePredictionProvider):
             pred_labels=pred_labels,
         )
         self._use_ground_truth_page_images = use_ground_truth_page_images
+        self._prediction_images_path = prediction_images_path
 
         self._supported_prediction_formats = [
             PredictionFormats.DOCTAGS,
@@ -91,6 +95,17 @@ class FilePredictionProvider(BasePredictionProvider):
         # Validate if the source_path exists
         if not self._prediction_source_path.is_dir():
             raise RuntimeError(f"Missing source path: {self._prediction_source_path}")
+
+        # Log the source path for the images
+        if prediction_format == PredictionFormats.DOCTAGS:
+            msg = "The prediction images will be loaded from "
+            if self._prediction_images_path:
+                msg += f"{str(self._prediction_images_path)}"
+            elif self._use_ground_truth_page_images:
+                msg += "the GT dataset"
+            else:
+                msg += f"{str(self._prediction_source_path)}"
+            _log.info(msg)
 
     def info(self) -> Dict:
         """Get information about the prediction provider."""
@@ -169,13 +184,20 @@ class FilePredictionProvider(BasePredictionProvider):
 
             page_image = None
 
-            if self._use_ground_truth_page_images:
+            # Try to get an image file for the predictions:
+            # 1. Check the pred_images_path.
+            # 2. Use the GT page image if the corresponding flag is set.
+            # 3. Look inside the same dir as the doctag files.
+            if self._prediction_images_path:
+                page_image_fn = self._prediction_images_path / f"{record.doc_id}.png"
+            elif self._use_ground_truth_page_images:
                 page_image = record.ground_truth_page_images[0]
             else:
-                # Check if an optional page image is present
                 page_image_fn = self._prediction_source_path / f"{record.doc_id}.png"
-                if page_image_fn.is_file():
-                    page_image = Image.open(page_image_fn)
+            if page_image_fn.is_file():
+                page_image = Image.open(page_image_fn)
+            else:
+                _log.warning("Failed to load pred image: %s", page_image_fn)
 
             # Build DoclingDocument
             doctags_page = DocTagsPage(tokens=doctags, image=page_image)

--- a/docs/DocTags_evaluations.md
+++ b/docs/DocTags_evaluations.md
@@ -1,0 +1,81 @@
+# Evaluate DocTag files using the FileProvider
+
+Assumptions:
+
+1. We have the ground truth data as an HF parquet dataset.
+2. We have a directory with doctag files with the naming convention: `<doc_id>.dt`, where `<doc_id>` must match the `document_id` column in the GT dataset.
+3. The same images from the GT will be used together with the `dt` files to construct the prediction documents.
+
+
+Overview:
+
+1. Run `create-eval` to package the file predictons as a dataset in HF parquet format.
+   - Pass the directory of the `dt` files in `--file-source-path`.
+   - Give an `--output-dir` to save the produced dataset.
+2. Run evaluations for each modality.
+   - Pass exactly the same path for `--output-dir` as in step 1.
+3. Run visualizations for each evaluation.
+   - Pass exactly the same path for `--output-dir` as in step 1.
+
+
+## Example
+
+Assuming:
+
+1. The GT in HF parquet format is in: `/Users/nli/data/DocLayNetV2/gt_dataset`.
+2. The `dt` files are in: `/Users/nli/data/SmolDocling_eval_data/SmolDocling_250M_DT_v2.1_gd_checkpoint_2200/dt`
+3. We want to run evaluations for the `layout` modality with visualizations.
+
+
+Samples of the doctag filenames:
+
+```
+05e45d1c6fd3c28a056038b8495f32d76ac8b13a8f917c0771b37fae8e5b62b9.dt
+541db2953d542412c66e6bcdad9aed8a1fc0ab4f5ca3981d013a999bc050b998.dt
+c7fc21b6389b304c60df5c5d8d354fc9d94b3a462cc37216fabd186b8491df55.dt
+6210509094e90aeb5c7f1f5dca17e89185b821740c2805fa087778bcc22fe84c.dt
+```
+
+How to evaluate:
+
+1. Generate the HF parquet dataset out of the `dt` files.
+
+```bash
+poetry run docling_eval \
+    create-eval \
+    --benchmark DocLayNetV2 \
+    --gt-dir "/Users/nli/data/DocLayNetV2/gt_dataset" \
+    --prediction-provider File \
+    --file-prediction-format doctags \
+    --file-source-path "/Users/nli/data/SmolDocling_eval_data/SmolDocling_250M_DT_v2.1_gd_checkpoint_2200/dt" \
+    --output-dir "/Users/nli/data/SmolDocling_eval_data/evals"
+```
+
+The generated HF parquet dataset of the predictions is in: `/Users/nli/data/SmolDocling_eval_data/evals/eval_dataset`
+
+Also it generates visualizations of the predictions inside: `/Users/nli/data/SmolDocling_eval_data/evals/eval_dataset/visualizations`
+
+
+2. Use the predictions dataset to make evaluations for the `layout` modality:
+
+```bash
+poetry run docling_eval \
+    evaluate \
+    --modality layout \
+    --benchmark DocLayNetV2 \
+    --output-dir "/Users/nli/data/SmolDocling_eval_data/evals"
+```
+The generated evaluations will be placed in: `/Users/nli/data/SmolDocling_eval_data/evals/evaluations/layout`
+
+
+3. Generate visualizations for the evaluations:
+
+```bash
+poetry run docling_eval \
+    visualize \
+    --modality layout \
+    --benchmark DocLayNetV2 \
+    --output-dir "/Users/nli/data/SmolDocling_eval_data/evals"
+```
+
+The evaluation visualizations will be in: `/Users/nli/data/SmolDocling_eval_data/evals/evaluations/layout`


### PR DESCRIPTION
This is used in case of DocTags:

- By default the images from GT will be used.
- The user can provide an external image path.
- Add documentation example how to evaluate doctag files.

https://github.com/docling-project/docling-eval/blob/nli/file_evaluations/docs/DocTags_evaluations.md