### PR TITLE
feat: add support for Google, AWS, and Azure prediction providers in cli

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,6 +91,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
       - name: Install package
-        run: uv pip install dist/*.whl[hyperscalers]
+        run: |
+          WHEEL_FILE=$(ls dist/*.whl)
+          uv pip install "${WHEEL_FILE}[hyperscalers]"
       - name: Run docling-eval
         run: docling-eval --help

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,6 +91,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
       - name: Install package
-        run: uv pip install dist/*.whl
+        run: |
+          uv pip install dist/*.whl
+          uv pip install ".[hyperscalers]"
       - name: Run docling-eval
         run: docling-eval --help

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,8 +91,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
       - name: Install package
-        run: |
-          uv pip install dist/*.whl
-          uv pip install ".[hyperscalers]"
+        run: uv pip install dist/*.whl[hyperscalers]
       - name: Run docling-eval
         run: docling-eval --help

--- a/docling_eval/cli/main.py
+++ b/docling_eval/cli/main.py
@@ -77,8 +77,17 @@ from docling_eval.evaluators.timings_evaluator import (
     DatasetTimingsEvaluation,
     TimingsEvaluator,
 )
+from docling_eval.prediction_providers.aws_prediction_provider import (
+    AWSTextractPredictionProvider,
+)
+from docling_eval.prediction_providers.azure_prediction_provider import (
+    AzureDocIntelligencePredictionProvider,
+)
 from docling_eval.prediction_providers.docling_provider import DoclingPredictionProvider
 from docling_eval.prediction_providers.file_provider import FilePredictionProvider
+from docling_eval.prediction_providers.google_prediction_provider import (
+    GoogleDocAIPredictionProvider,
+)
 from docling_eval.prediction_providers.tableformer_provider import (
     TableFormerPredictionProvider,
 )
@@ -393,6 +402,21 @@ def get_prediction_provider(
 
     elif provider_type == PredictionProviderType.TABLEFORMER:
         return TableFormerPredictionProvider(
+            do_visualization=do_visualization,
+            ignore_missing_predictions=True,
+        )
+    elif provider_type == PredictionProviderType.GOOGLE:
+        return GoogleDocAIPredictionProvider(
+            do_visualization=do_visualization,
+            ignore_missing_predictions=True,
+        )
+    elif provider_type == PredictionProviderType.AWS:
+        return AWSTextractPredictionProvider(
+            do_visualization=do_visualization,
+            ignore_missing_predictions=True,
+        )
+    elif provider_type == PredictionProviderType.AZURE:
+        return AzureDocIntelligencePredictionProvider(
             do_visualization=do_visualization,
             ignore_missing_predictions=True,
         )


### PR DESCRIPTION
This PR fixes the error and adds support for Hyperscalers
```
docling-eval create-eval  --benchmark XFUND --split val   --output-dir ./benchmarks/XFUND  --end-index 1  --prediction-provider Google            ─╯
2025-05-30 16:21:21,032 - ERROR - Error creating prediction provider: Unsupported prediction provider: PredictionProviderType.GOOGLE
```