### PR TITLE
fix: Important fixes for parquet serialization / deserialization, optimizations

### DIFF
--- a/docling_eval/datamodels/dataset_record.py
+++ b/docling_eval/datamodels/dataset_record.py
@@ -109,12 +109,14 @@ class DatasetRecord(
             self.get_field_alias("ground_truth_pictures"): self.ground_truth_pictures,
             self.get_field_alias("ground_truth_segmented_pages"): seg_adapter.dump_json(
                 self.ground_truth_segmented_pages
-            ),
+            ).decode("utf-8"),
             self.get_field_alias(
                 "ground_truth_page_images"
             ): self.ground_truth_page_images,
             self.get_field_alias("mime_type"): self.mime_type,
-            self.get_field_alias("modalities"): list(self.modalities),
+            self.get_field_alias("modalities"): list(
+                [m.value for m in self.modalities]
+            ),
         }
         if isinstance(self.original, Path):
             with self.original.open("rb") as f:
@@ -152,7 +154,7 @@ class DatasetRecord(
             data[gt_doc_alias] = json.loads(data[gt_doc_alias])
 
         gt_seg_pages_alias = cls.get_field_alias("ground_truth_segmented_pages")
-        if gt_seg_pages_alias in data and isinstance(data[gt_seg_pages_alias], bytes):
+        if gt_seg_pages_alias in data and isinstance(data[gt_seg_pages_alias], str):
             data[gt_seg_pages_alias] = seg_adapter.validate_json(
                 data[gt_seg_pages_alias]
             )
@@ -231,6 +233,7 @@ class DatasetRecordWithPrediction(DatasetRecord):
                 ),
                 cls.get_field_alias("prediction_format"): Value("string"),
                 cls.get_field_alias("prediction_timings"): Value("string"),
+                cls.get_field_alias("original_prediction"): Value("string"),
             }
         )
 
@@ -239,9 +242,13 @@ class DatasetRecordWithPrediction(DatasetRecord):
         record.update(
             {
                 self.get_field_alias("prediction_format"): self.prediction_format.value,
-                self.get_field_alias("prediction_timings"): self.prediction_timings,
-                self.get_field_alias("predictor_info"): self.predictor_info,
-                self.get_field_alias("status"): (self.status),
+                self.get_field_alias("prediction_timings"): (
+                    json.dumps(self.prediction_timings)
+                    if self.prediction_timings is not None
+                    else None
+                ),
+                self.get_field_alias("predictor_info"): json.dumps(self.predictor_info),
+                self.get_field_alias("status"): self.status.value,
             }
         )
 
@@ -253,7 +260,9 @@ class DatasetRecordWithPrediction(DatasetRecord):
                     ),
                     self.get_field_alias(
                         "predicted_segmented_pages"
-                    ): seg_adapter.dump_json(self.predicted_segmented_pages),
+                    ): seg_adapter.dump_json(self.predicted_segmented_pages).decode(
+                        "utf-8"
+                    ),
                     self.get_field_alias("predicted_pictures"): self.predicted_pictures,
                     self.get_field_alias(
                         "predicted_page_images"
@@ -290,14 +299,19 @@ class DatasetRecordWithPrediction(DatasetRecord):
         if info_alias in data and isinstance(data[info_alias], str):
             data[info_alias] = json.loads(data[info_alias])
 
+        timings_alias = cls.get_field_alias("prediction_timings")
+        if timings_alias in data and isinstance(data[timings_alias], str):
+            # try:
+            data[timings_alias] = json.loads(data[timings_alias])
+            # except json.JSONDecodeError:
+            #    data[timings_alias] = None
+
         pred_doc_alias = cls.get_field_alias("predicted_doc")
         if pred_doc_alias in data and isinstance(data[pred_doc_alias], str):
             data[pred_doc_alias] = json.loads(data[pred_doc_alias])
 
         pred_seg_pages_alias = cls.get_field_alias("predicted_segmented_pages")
-        if pred_seg_pages_alias in data and isinstance(
-            data[pred_seg_pages_alias], bytes
-        ):
+        if pred_seg_pages_alias in data and isinstance(data[pred_seg_pages_alias], str):
             data[pred_seg_pages_alias] = seg_adapter.validate_json(
                 data[pred_seg_pages_alias]
             )

--- a/docling_eval/dataset_builders/dataset_builder.py
+++ b/docling_eval/dataset_builders/dataset_builder.py
@@ -12,7 +12,10 @@ from docling_core.types.doc.document import ImageRefMode
 from huggingface_hub import snapshot_download
 from pydantic import BaseModel
 
-from docling_eval.datamodels.dataset_record import DatasetRecord
+from docling_eval.datamodels.dataset_record import (
+    DatasetRecord,
+    DatasetRecordWithPrediction,
+)
 from docling_eval.prediction_providers.base_prediction_provider import (
     TRUE_HTML_EXPORT_LABELS,
 )
@@ -327,7 +330,10 @@ class BaseEvaluationDatasetBuilder:
                     """
 
             save_shard_to_disk(
-                items=record_list, dataset_path=test_dir, shard_id=chunk_count
+                items=record_list,
+                dataset_path=test_dir,
+                shard_id=chunk_count,
+                features=DatasetRecord.features(),
             )
             count += len(record_list)
             chunk_count += 1

--- a/docling_eval/dataset_builders/doclaynet_v1_builder.py
+++ b/docling_eval/dataset_builders/doclaynet_v1_builder.py
@@ -288,7 +288,11 @@ class DocLayNetV1DatasetBuilder(BaseEvaluationDatasetBuilder):
         if self.dataset_local_path is not None:
             path = str(self.dataset_local_path)
         # Load dataset from the retrieved path
-        ds = load_dataset(path, split=self.split)
+        ds = load_dataset(
+            path,
+            data_files={self.split: f"data/{self.split}-*.parquet"},
+            split=self.split,
+        )
 
         # Apply HuggingFace's select method for index ranges
         total_ds_len = len(ds)

--- a/docling_eval/prediction_providers/base_prediction_provider.py
+++ b/docling_eval/prediction_providers/base_prediction_provider.py
@@ -395,7 +395,10 @@ class BasePredictionProvider:
             record_chunk = [r.as_record_dict() for r in record_chunk]
 
             save_shard_to_disk(
-                items=record_chunk, dataset_path=test_dir, shard_id=chunk_count
+                items=record_chunk,
+                dataset_path=test_dir,
+                shard_id=chunk_count,
+                features=DatasetRecordWithPrediction.features(),
             )
             count += len(record_chunk)
             chunk_count += 1

--- a/docling_eval/utils/utils.py
+++ b/docling_eval/utils/utils.py
@@ -431,26 +431,25 @@ def save_shard_to_disk(
     shard_id: int = 0,
     features: Optional[Features] = None,
     shard_format: str = "parquet",
-):
-    """Save shard of to disk."""
+) -> None:
+    """Save shard to disk."""
+    if not items:
+        return
 
-    batch = Dataset.from_list(items)  # , features=features)
+    # Use features if provided to avoid schema inference
+    batch = Dataset.from_list(items, features=features)
 
     output_file = dataset_path / f"shard_{thread_id:06}_{shard_id:06}.{shard_format}"
     if shard_format == "json":
         batch.to_json(output_file)
-
     elif shard_format == "parquet":
         batch.to_parquet(output_file)
-
     else:
         raise ValueError(f"Unsupported shard_format: {shard_format}")
 
     logging.info(f"Saved shard {shard_id} to {output_file} with {len(items)} documents")
 
     shard_id += 1
-
-    return shard_id, [], 0
 
 
 def dataset_exists(

--- a/tests/test_cvat_to_docling_eval_e2e.py
+++ b/tests/test_cvat_to_docling_eval_e2e.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Example pipeline that demonstrates chaining CVAT annotation processing 
+through to layout evaluation.
+
+This script:
+1. Converts CVAT annotation files to DoclingDocument JSON
+2. Creates a ground truth dataset using FileDatasetBuilder 
+3. Creates an evaluation dataset using FilePredictionProvider
+4. Runs layout evaluation on the results
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import List
+
+import pytest
+from dotenv import load_dotenv
+
+from docling_eval.cli.main import evaluate, get_prediction_provider
+from docling_eval.cvat_tools.cvat_to_docling import convert_cvat_to_docling
+from docling_eval.datamodels.types import (
+    BenchMarkNames,
+    EvaluationModality,
+    PredictionFormats,
+    PredictionProviderType,
+)
+from docling_eval.dataset_builders.file_dataset_builder import FileDatasetBuilder
+from docling_eval.prediction_providers.file_provider import FilePredictionProvider
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+_log = logging.getLogger(__name__)
+
+
+IS_CI = bool(os.getenv("CI"))
+load_dotenv()
+
+
+def find_cvat_cases(root_dir: Path) -> List[tuple[Path, Path]]:
+    """
+    Find CVAT annotation XML files and corresponding input files.
+
+    Args:
+        root_dir: Root directory containing CVAT cases
+
+    Returns:
+        List of tuples (xml_path, input_path)
+    """
+    cases = []
+
+    # Find all case directories (directories starting with "case")
+    case_dirs = sorted(
+        [d for d in root_dir.iterdir() if d.is_dir() and d.name.startswith("case")]
+    )
+
+    # Process each case directory
+    for case_dir in case_dirs:
+        # Extract case basename from directory name
+        case_basename = case_dir.name
+        # Construct XML path: case directory's parent + case_basename + "_annotations.xml"
+        annotations_xml = case_dir.parent / f"{case_basename}_annotations.xml"
+
+        if annotations_xml.exists():
+            # Find all image/PDF files in case directory
+            sample_paths = []
+            for ext in [
+                "*.pdf",
+                "*.PDF",
+                "*.png",
+                "*.PNG",
+                "*.jpg",
+                "*.JPG",
+                "*.jpeg",
+                "*.JPEG",
+                "*.tif",
+                "*.TIF",
+                "*.tiff",
+                "*.TIFF",
+                "*.bmp",
+                "*.BMP",
+            ]:
+                sample_paths.extend(sorted(case_dir.glob(ext)))
+
+            # Add each sample file as a case
+            for sample_path in sorted(sample_paths):
+                cases.append((annotations_xml, sample_path))
+
+    return cases
+
+
+def step1_convert_cvat_to_json(
+    cvat_root_dir: Path, output_json_dir: Path
+) -> List[Path]:
+    """
+    Step 1: Convert CVAT annotation files to DoclingDocument JSON.
+
+    Args:
+        cvat_root_dir: Directory containing CVAT annotation files
+        output_json_dir: Directory to save JSON outputs
+
+    Returns:
+        List of paths to created JSON files
+    """
+    _log.info("=== Step 1: Converting CVAT annotations to DoclingDocument JSON ===")
+
+    output_json_dir.mkdir(parents=True, exist_ok=True)
+    json_files = []
+
+    # Find CVAT cases
+    cases = find_cvat_cases(cvat_root_dir)
+    _log.info(f"Found {len(cases)} CVAT cases to process")
+
+    for xml_path, input_path in cases:
+        _log.info(f"Processing: {xml_path} with input {input_path}")
+
+        try:
+            # Convert CVAT to DoclingDocument
+            doc = convert_cvat_to_docling(xml_path, input_path)
+
+            if doc is not None:
+                # Save as JSON
+                output_name = f"{input_path.stem}_{xml_path.stem}.json"
+                json_path = output_json_dir / output_name
+
+                with open(json_path, "w", encoding="utf-8") as f:
+                    doc.save_as_json(json_path)
+                json_files.append(json_path)
+                _log.info(f"✓ Saved DoclingDocument JSON to: {json_path}")
+            else:
+                _log.error(f"✗ Failed to convert {input_path}")
+
+        except Exception as e:
+            raise e
+            _log.error(f"✗ Error processing {input_path}: {e}")
+
+    _log.info(f"Step 1 complete: Created {len(json_files)} JSON files")
+    return json_files
+
+
+def step2_create_gt_dataset(json_dir: Path, gt_dataset_dir: Path) -> None:
+    """
+    Step 2: Create ground truth dataset from JSON files using FileDatasetBuilder.
+
+    Args:
+        json_dir: Directory containing DoclingDocument JSON files
+        gt_dataset_dir: Directory to save ground truth dataset
+    """
+    _log.info("=== Step 2: Creating ground truth dataset ===")
+
+    # Create FileDatasetBuilder with only JSON files
+    dataset_builder = FileDatasetBuilder(
+        name="CVAT_GT_Dataset",
+        dataset_source=json_dir,
+        target=gt_dataset_dir,
+        split="test",
+        file_extensions=["json"],  # Only process JSON files
+    )
+
+    # Save the dataset to disk with visualization
+    dataset_builder.save_to_disk(chunk_size=50, do_visualization=True)
+
+    _log.info(f"Step 2 complete: Ground truth dataset saved to {gt_dataset_dir}")
+
+
+def step3_create_eval_dataset(
+    json_dir: Path, gt_dataset_dir: Path, eval_dataset_dir: Path
+) -> None:
+    """
+    Step 3: Create evaluation dataset using FilePredictionProvider.
+
+    Args:
+        json_dir: Directory containing JSON prediction files (same as GT for this example)
+        gt_dataset_dir: Ground truth dataset directory
+        eval_dataset_dir: Directory to save evaluation dataset
+    """
+    _log.info("=== Step 3: Creating evaluation dataset ===")
+
+    # Create FilePredictionProvider
+    file_provider = FilePredictionProvider(
+        prediction_format=PredictionFormats.JSON,
+        source_path=json_dir,
+        do_visualization=True,
+        ignore_missing_files=True,
+        ignore_missing_predictions=True,
+        use_ground_truth_page_images=True,
+    )
+
+    # Create prediction dataset
+    file_provider.create_prediction_dataset(
+        name="CVAT_Eval_Dataset",
+        gt_dataset_dir=gt_dataset_dir,
+        target_dataset_dir=eval_dataset_dir,
+        split="test",
+        chunk_size=50,
+    )
+
+    _log.info(f"Step 3 complete: Evaluation dataset saved to {eval_dataset_dir}")
+
+
+def step4_run_evaluation(eval_dataset_dir: Path, evaluation_output_dir: Path) -> None:
+    """
+    Step 4: Run layout evaluation on the evaluation dataset.
+
+    Args:
+        eval_dataset_dir: Directory containing evaluation dataset
+        evaluation_output_dir: Directory to save evaluation results
+    """
+    _log.info("=== Step 4: Running layout evaluation ===")
+
+    evaluation_output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Run layout evaluation
+    evaluation_result = evaluate(
+        modality=EvaluationModality.LAYOUT,
+        benchmark=BenchMarkNames.CVAT,
+        idir=eval_dataset_dir,
+        odir=evaluation_output_dir,
+        split="test",
+    )
+
+    if evaluation_result:
+        _log.info("✓ Layout evaluation completed successfully")
+        _log.info(f"Results saved to: {evaluation_output_dir}")
+
+        # Print some basic stats
+        _log.info(f"Evaluated samples: {evaluation_result.evaluated_samples}")
+        _log.info(f"Mean mAP: {evaluation_result.mAP:.4f}")
+    else:
+        _log.error("✗ Layout evaluation failed")
+
+    # Run tree evaluation
+    evaluation_result = evaluate(
+        modality=EvaluationModality.DOCUMENT_STRUCTURE,
+        benchmark=BenchMarkNames.CVAT,
+        idir=eval_dataset_dir,
+        odir=evaluation_output_dir,
+        split="test",
+    )
+
+    if evaluation_result:
+        _log.info("✓ Document structure evaluation completed successfully")
+        _log.info(f"Results saved to: {evaluation_output_dir}")
+
+        # Print some basic stats
+        _log.info(f"Evaluated samples: {evaluation_result.evaluated_samples}")
+        _log.info(
+            f"Mean edit distance: {evaluation_result.edit_distance_stats.mean:.4f}"
+        )
+    else:
+        _log.error("✗ Document structure evaluation failed")
+
+
+@pytest.mark.skipif(IS_CI, reason="Skipping test in CI because the test is too heavy.")
+def test_cvat_to_docling_eval_e2e():
+    """Main pipeline execution."""
+
+    # Define directory structure
+    base_dir = Path("./scratch/cvat_evaluation_pipeline")
+
+    # Input: CVAT annotation files (update this path to your CVAT data)
+    cvat_input_dir = Path("./tests/data/cvat_pdfs_dataset_e2e")
+
+    # Pipeline directories
+    json_output_dir = base_dir / "docling_json_output"
+    gt_dataset_dir = base_dir / "gt_dataset"
+    eval_dataset_dir = base_dir / "eval_dataset"
+    evaluation_results_dir = base_dir / "evaluation_results"
+
+    _log.info("Starting CVAT to Evaluation Pipeline")
+    _log.info(f"Input CVAT directory: {cvat_input_dir}")
+    _log.info(f"Output base directory: {base_dir}")
+
+    try:
+        # Step 1: Convert CVAT annotations to JSON
+        json_files = step1_convert_cvat_to_json(cvat_input_dir, json_output_dir)
+
+        if not json_files:
+            _log.error("No JSON files were created. Pipeline cannot continue.")
+            return
+
+        # Step 2: Create ground truth dataset
+        step2_create_gt_dataset(json_output_dir, gt_dataset_dir)
+
+        # Step 3: Create evaluation dataset
+        step3_create_eval_dataset(json_output_dir, gt_dataset_dir, eval_dataset_dir)
+
+        # Step 4: Run layout evaluation
+        step4_run_evaluation(eval_dataset_dir, evaluation_results_dir)
+
+        _log.info("=== Pipeline completed successfully! ===")
+        _log.info(f"Results available in: {base_dir}")
+
+    except Exception as e:
+        _log.error(f"Pipeline failed with error: {e}")
+        raise


### PR DESCRIPTION
- Ensures the `DatasetRecord.features()` are always used when constructing a huggingface `Dataset`, which is crucial for validation what goes into the columns.
- Updates `DatasetRecord.as_record_dict` and model validators to deal correctly with the serialized types.
- Fixes selective downloading of `test` split for DocLayNet v1 (speeds up tests)