### PR TITLE
fix: ocr visualization and add ocr recognition metrics

### DIFF
--- a/docling_eval/cli/main.py
+++ b/docling_eval/cli/main.py
@@ -603,7 +603,7 @@ def evaluate(
             json.dump(evaluation.model_dump(), fd, indent=2, sort_keys=True)
 
     elif modality == EvaluationModality.OCR:
-        ocr_evaluator = OCREvaluator()
+        ocr_evaluator = OCREvaluator(intermediate_evaluations_path=odir)
         evaluation = ocr_evaluator(  # type: ignore
             idir,
             split=split,

--- a/docling_eval/evaluators/ocr/evaluation_models.py
+++ b/docling_eval/evaluators/ocr/evaluation_models.py
@@ -10,9 +10,10 @@ class _CalculationConstants:
     CHAR_NORMALIZE_MAP: Dict[str, str] = {
         "ﬁ": "fi",
         "ﬂ": "fl",
-        """: "'", """: "'",
-        '"': '"',
-        '"': '"',
+        "“": '"',
+        "”": '"',
+        "‘": "'",
+        "’": "'",
         "—": "-",
         "–": "-",
         "\xa0": " ",
@@ -25,6 +26,8 @@ class Word(TextCell):
     matched: bool = Field(default=False)
     ignore_zone: Optional[bool] = None
     to_remove: Optional[bool] = None
+    # number of GT words represented by this Word after merging
+    word_weight: int = Field(default=1)
 
     @property
     def bbox(self) -> BoundingBox:
@@ -57,6 +60,15 @@ class OcrMetricsSummary(BaseModel):
     word_accuracy_insensitive: float = 0.0
     character_accuracy_sensitive: float = 0.0
     character_accuracy_insensitive: float = 0.0
+    # for dataset-level union aggregation
+    tp_words_weighted: float = 0.0
+    perfect_matches_sensitive_weighted: float = 0.0
+    perfect_matches_insensitive_weighted: float = 0.0
+    sum_ed_sensitive_tp: float = 0.0
+    sum_ed_insensitive_tp: float = 0.0
+    sum_max_len_tp: float = 0.0
+    text_len_fp: float = 0.0
+    text_len_fn: float = 0.0
 
     class Config:
         populate_by_name = True

--- a/docling_eval/evaluators/ocr/evaluation_models.py
+++ b/docling_eval/evaluators/ocr/evaluation_models.py
@@ -72,3 +72,21 @@ class OcrDatasetEvaluationResult(BaseModel):
     f1_score: float = 0.0
     recall: float = 0.0
     precision: float = 0.0
+
+
+class ErrorWord(BaseModel):
+    text: str
+    confidence: Optional[float] = None
+    bounding_box: BoundingBox
+
+
+class SubstitutionError(BaseModel):
+    ground_truth: ErrorWord
+    prediction: ErrorWord
+
+
+class DocumentErrorReport(BaseModel):
+    doc_id: str
+    substitution_errors: List[SubstitutionError]
+    insertion_errors_fp: List[ErrorWord]
+    deletion_errors_fn: List[ErrorWord]

--- a/docling_eval/evaluators/ocr/processing_utils.py
+++ b/docling_eval/evaluators/ocr/processing_utils.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 from typing import Any, Dict, List, Optional, Tuple
 
+import edit_distance
 from docling_core.types.doc import BoundingBox, CoordOrigin
 from docling_core.types.doc.page import (
     BoundingRectangle,
@@ -254,3 +255,21 @@ def parse_segmented_pages(
             traceback.print_exc()
             continue
     return segmented_pages_map if segmented_pages_map else None
+
+
+def replace_chars_by_map(text: str, char_map: Dict[str, str]) -> str:
+    """Replaces characters in a string based on a provided mapping."""
+    if not char_map:
+        return text
+    return "".join(char_map.get(char, char) for char in text)
+
+
+def calculate_edit_distance(
+    str1: str, str2: str, normalize_map: Optional[Dict[str, str]] = None
+) -> int:
+    """Calculates the Levenshtein edit distance between two strings after optional normalization."""
+    map_to_use = normalize_map or {}
+    str1_normalized = replace_chars_by_map(str1, map_to_use)
+    str2_normalized = replace_chars_by_map(str2, map_to_use)
+    sm = edit_distance.SequenceMatcher(str1_normalized, str2_normalized)
+    return sm.distance()

--- a/docling_eval/evaluators/ocr/processing_utils.py
+++ b/docling_eval/evaluators/ocr/processing_utils.py
@@ -268,8 +268,12 @@ def calculate_edit_distance(
     str1: str, str2: str, normalize_map: Optional[Dict[str, str]] = None
 ) -> int:
     """Calculates the Levenshtein edit distance between two strings after optional normalization."""
+    str1_stripped = str1.strip()
+    str2_stripped = str2.strip()
+
     map_to_use = normalize_map or {}
-    str1_normalized = replace_chars_by_map(str1, map_to_use)
-    str2_normalized = replace_chars_by_map(str2, map_to_use)
+    str1_normalized = replace_chars_by_map(str1_stripped, map_to_use)
+    str2_normalized = replace_chars_by_map(str2_stripped, map_to_use)
+
     sm = edit_distance.SequenceMatcher(str1_normalized, str2_normalized)
     return sm.distance()

--- a/docling_eval/evaluators/ocr/processing_utils.py
+++ b/docling_eval/evaluators/ocr/processing_utils.py
@@ -18,7 +18,9 @@ from docling_eval.evaluators.ocr.geometry_utils import create_polygon_from_bbox
 _log = logging.getLogger(__name__)
 
 
-def extract_word_from_text_cell(text_cell: TextCell, page_height: float) -> Word:
+def extract_word_from_text_cell(
+    text_cell: TextCell, page_height: float, is_ground_truth: bool = False
+) -> Word:
     rect_to_process = text_cell.rect
     if rect_to_process.coord_origin != CoordOrigin.TOPLEFT:
         rect_to_process = rect_to_process.to_top_left_origin(page_height=page_height)
@@ -43,10 +45,13 @@ def extract_word_from_text_cell(text_cell: TextCell, page_height: float) -> Word
     ):
         is_vertical_flag = True
 
+    # For GT: set orig to the GT text; for predictions: prefer provided orig, fallback to text
+    orig_val = text_cell.text if is_ground_truth else (text_cell.orig or text_cell.text)
+
     return Word(
         rect=rect_to_process,
         text=text_cell.text,
-        orig=text_cell.orig,
+        orig=orig_val,
         text_direction=text_cell.text_direction,
         confidence=text_cell.confidence,
         from_ocr=text_cell.from_ocr,
@@ -95,10 +100,12 @@ def merge_words_into_one(
             text_direction=TextDirection.LEFT_TO_RIGHT,
             vertical=False,
             polygon=create_polygon_from_bbox(default_bbox),
+            word_weight=1,
         )
 
     separator: str = " " if add_space_between_words else ""
-    merged_text_parts = []
+    merged_text_parts: List[str] = []
+    merged_orig_parts: List[str] = []
 
     min_left: float = float("inf")
     min_top: float = float("inf")
@@ -111,6 +118,7 @@ def merge_words_into_one(
 
     for word_item in sorted_words:
         merged_text_parts.append(word_item.text)
+        merged_orig_parts.append(word_item.orig)
         current_bbox = word_item.bbox
         min_left = min(min_left, current_bbox.l)
         min_top = min(min_top, current_bbox.t)
@@ -118,6 +126,7 @@ def merge_words_into_one(
         max_bottom = max(max_bottom, current_bbox.b)
 
     merged_text: str = separator.join(merged_text_parts)
+    merged_orig: str = separator.join(merged_orig_parts)
 
     merged_bbox = BoundingBox(
         l=min_left,
@@ -130,15 +139,18 @@ def merge_words_into_one(
     merged_polygon: List[List[float]] = create_polygon_from_bbox(merged_bbox)
     merged_rect = BoundingRectangle.from_bounding_box(merged_bbox)
 
+    total_weight = sum(getattr(w, "word_weight", 1) for w in sorted_words)
+
     return Word(
         text=merged_text,
         rect=merged_rect,
-        orig=merged_text,
+        orig=merged_orig,
         confidence=first_word_for_metadata.confidence,
         from_ocr=any(w.from_ocr for w in sorted_words),
         text_direction=first_word_for_metadata.text_direction,
         vertical=first_word_for_metadata.vertical,
         polygon=merged_polygon,
+        word_weight=total_weight,
     )
 
 
@@ -195,6 +207,53 @@ class _IgnoreZoneFilter:
             return False
         else:
             return True
+
+
+class _IgnoreZoneFilterHWR(_IgnoreZoneFilter):
+    def filter_words_in_ignore_zones(
+        self, prediction_words: List[Word], ground_truth_words: List[Word]
+    ) -> Tuple[List[Word], List[Word], List[Word]]:
+        ignore_zones: List[Word] = []
+
+        # Identify ignore zones from GT and mark them for removal from GT
+        for gt_word in ground_truth_words:
+            if gt_word.ignore_zone is True:
+                ignore_zones.append(gt_word)
+                gt_word.to_remove = True
+
+        # Remove predictions that intersect the ignore zones sufficiently (IoU-based)
+        for zone in ignore_zones:
+            zone_bbox = zone.bbox
+            for pred_word in prediction_words:
+                if self._intersect_by_iou(pred_word.bbox, zone_bbox):
+                    pred_word.to_remove = True
+
+        filtered_ground_truth_words: List[Word] = [
+            w for w in ground_truth_words if not w.to_remove
+        ]
+        filtered_prediction_words: List[Word] = [
+            w for w in prediction_words if not w.to_remove
+        ]
+
+        return filtered_ground_truth_words, filtered_prediction_words, ignore_zones
+
+    def _intersect_by_iou(
+        self, bbox1: BoundingBox, bbox2: BoundingBox, iou_threshold: float = 0.3
+    ) -> bool:
+        # Ratio overlaps relative to bbox1 (prediction)
+        x_overlap = bbox1.x_overlap_with(bbox2)
+        y_overlap = bbox1.y_overlap_with(bbox2)
+        x_overlap_ratio = 0.0 if bbox1.width == 0 else x_overlap / bbox1.width
+        y_overlap_ratio = 0.0 if bbox1.height == 0 else y_overlap / bbox1.height
+
+        # Near-contained special-case
+        if x_overlap_ratio > 0.95 and y_overlap_ratio > 0.95:
+            return True
+
+        intersection_area = bbox1.intersection_area_with(bbox2)
+        union_area = bbox1.union_area_with(bbox2)
+        iou = (intersection_area / union_area) if union_area > 0 else 0.0
+        return iou >= iou_threshold
 
 
 def parse_segmented_pages(

--- a/docling_eval/evaluators/ocr_evaluator.py
+++ b/docling_eval/evaluators/ocr_evaluator.py
@@ -1,5 +1,6 @@
 import copy
 import glob
+import io
 import json
 import logging
 import traceback
@@ -285,7 +286,18 @@ class OCRVisualizer:
 
                 image_item: Union[dict, Image.Image] = page_images_data[0]
                 if isinstance(image_item, dict):
-                    base_image: Image.Image = image_item["image"]
+                    if "image" in image_item and isinstance(
+                        image_item["image"], Image.Image
+                    ):
+                        base_image: Image.Image = image_item["image"]
+                    elif "bytes" in image_item and image_item["bytes"]:
+                        base_image: Image.Image = Image.open(
+                            io.BytesIO(image_item["bytes"])
+                        )
+                    elif "path" in image_item and image_item["path"]:
+                        base_image: Image.Image = Image.open(image_item["path"])
+                    else:
+                        raise ValueError(f"Unsupported image_item format: {image_item}")
                 else:
                     base_image = image_item
                 if base_image.mode != "RGB":

--- a/docling_eval/evaluators/ocr_evaluator.py
+++ b/docling_eval/evaluators/ocr_evaluator.py
@@ -244,7 +244,7 @@ class OCRVisualizer:
                 "arial.ttf", size=10
             )
         except IOError:
-            self._rendering_font = self._default_font
+            self._rendering_font = self._default_font  # type: ignore
 
     def __call__(
         self,
@@ -262,6 +262,20 @@ class OCRVisualizer:
         hf_dataset: Dataset = load_dataset(
             "parquet", data_files={data_split_name: path_to_parquet_files}
         )
+
+        empty_bounding_rect = BoundingRectangle(
+            r_x0=0,
+            r_y0=0,
+            r_x1=0,
+            r_y1=0,
+            r_x2=0,
+            r_y2=0,
+            r_x3=0,
+            r_y3=0,
+            coord_origin=CoordOrigin.TOPLEFT,
+        )
+        empty_page_dims = PageGeometry(angle=0, rect=empty_bounding_rect)
+        empty_segmented_page = SegmentedPage(dimension=empty_page_dims)
 
         generated_visualization_paths: List[Path] = []
         if hf_dataset and data_split_name in hf_dataset:
@@ -349,10 +363,10 @@ class OCRVisualizer:
                     prediction_words=raw_pred_words,
                     ground_truth_words=raw_gt_words,
                     prediction_segmented_page_metadata=(
-                        pred_page if pred_page else SegmentedPage()
+                        pred_page if pred_page else empty_segmented_page
                     ),
                     ground_truth_segmented_page_metadata=(
-                        gt_page if gt_page else SegmentedPage()
+                        gt_page if gt_page else empty_segmented_page
                     ),
                 )
 

--- a/docling_eval/evaluators/ocr_evaluator.py
+++ b/docling_eval/evaluators/ocr_evaluator.py
@@ -285,21 +285,22 @@ class OCRVisualizer:
                         prediction_segmented_pages = parsed_pred_pages
 
                 image_item: Union[dict, Image.Image] = page_images_data[0]
+                base_image: Image.Image
+
                 if isinstance(image_item, dict):
                     if "image" in image_item and isinstance(
                         image_item["image"], Image.Image
                     ):
-                        base_image: Image.Image = image_item["image"]
+                        base_image = image_item["image"]
                     elif "bytes" in image_item and image_item["bytes"]:
-                        base_image: Image.Image = Image.open(
-                            io.BytesIO(image_item["bytes"])
-                        )
+                        base_image = Image.open(io.BytesIO(image_item["bytes"]))
                     elif "path" in image_item and image_item["path"]:
-                        base_image: Image.Image = Image.open(image_item["path"])
+                        base_image = Image.open(image_item["path"])
                     else:
                         raise ValueError(f"Unsupported image_item format: {image_item}")
                 else:
                     base_image = image_item
+
                 if base_image.mode != "RGB":
                     base_image = base_image.convert("RGB")
 


### PR DESCRIPTION
**Visualization Fixes**
* Updated side-by-side canvas to compare ground truth (GT) vs. predictions, with per-word overlays.
* For mismatched true positives, the overlay shows the label as: pred_text
* Included a stitched legend and summary statistics (TP/FP/FN counts, Precision, Recall, and F1 score).

**Recognition Metrics**
* New metrics added (previously we only had the detection metrics, now we have detection + recognition metrics):
  * Word accuracy (case-sensitive and case-insensitive).
  * Character accuracy (case-sensitive and insensitive), using union-based edit distance.
* Edit distance is calculated using standard Levenshtein:
  * String trimming or character normalization is applied.
  * Case-insensitive metrics are computed using uppercase versions of the strings.
* Aggregation is union-based by default (configurable).
* Recognition mismatches:
  * Explicitly flagged as `is_true_positive=False` in metadata.
  * Shown as incorrect in the visualization.
* Ignore zone:
  * Added Optional IoU-based (HWR) - currently not used but can be enabled. 

**Word Merging and Weighting Fixes**
* Added `word_weight` to correctly assign credit for merged GT words in recognition metrics.
* Merged words now retain both `text` and `orig` values:
  * GT `orig` uses the ground truth text.

**Ignore-Zone Filtering**
* **Default filter**: Removes words with less than 10% axis overlap relative to word size.
* **HWR filter**: Removes GT or predicted zones with:
  * IoU ≥ 0.3, or
  * ≥ 95% overlap on both axes (near-contained).
* Filter type is selectable via `ignore_zone_filter_type` ("default" or "hwr").

**Aggregation and Reporting**
* Detection metrics (Precision, Recall, F1) are calculated at the dataset level.
* Recognition aggregation mode is configurable:
  * Default is `"union"`, with `"mean"` also available.
* Per-document evaluation metadata includes:
  * TP pairs with edit distances,
  * FPs and FNs