### PR TITLE
feat: integrate textline_cells based OCR evaluation

### DIFF
--- a/docling_eval/cli/main.py
+++ b/docling_eval/cli/main.py
@@ -84,6 +84,7 @@ from docling_eval.evaluators.markdown_text_evaluator import (
     DatasetMarkdownEvaluation,
     MarkdownTextEvaluator,
 )
+from docling_eval.evaluators.ocr.evaluation_models import TextCellUnit
 from docling_eval.evaluators.ocr_evaluator import (
     OcrDatasetEvaluationResult,
     OCREvaluator,
@@ -603,7 +604,17 @@ def evaluate(
             json.dump(evaluation.model_dump(), fd, indent=2, sort_keys=True)
 
     elif modality == EvaluationModality.OCR:
-        ocr_evaluator = OCREvaluator(intermediate_evaluations_path=odir)
+        if benchmark in [BenchMarkNames.XFUND, BenchMarkNames.PIXPARSEIDL]:
+            text_unit = TextCellUnit.LINE
+        else:
+            text_unit = TextCellUnit.WORD
+
+        logging.info(f"Benchmark received in evaluate: {benchmark} ({type(benchmark)})")
+        logging.info(f"Text unit set to {text_unit}")
+
+        ocr_evaluator = OCREvaluator(
+            intermediate_evaluations_path=odir, text_unit=text_unit
+        )
         evaluation = ocr_evaluator(  # type: ignore
             idir,
             split=split,

--- a/docling_eval/dataset_builders/funsd_builder.py
+++ b/docling_eval/dataset_builders/funsd_builder.py
@@ -263,6 +263,16 @@ class FUNSDDatasetBuilder(BaseEvaluationDatasetBuilder):
             )
             cell_by_id[cell_id] = cell
 
+            if cell_text and bbox_instance:
+                seg_page.textline_cells.append(
+                    TextCell(
+                        from_ocr=True,
+                        rect=BoundingRectangle.from_bounding_box(bbox_instance),
+                        text=cell_text,
+                        orig=cell_text,
+                    )
+                )
+
             for word in item.get("words", []):
                 text = word.get("text", None)
                 bbox = word.get("box", None)

--- a/docling_eval/dataset_builders/pixparse_builder.py
+++ b/docling_eval/dataset_builders/pixparse_builder.py
@@ -54,11 +54,9 @@ class PixparseDatasetBuilder(BaseEvaluationDatasetBuilder):
     def _create_ground_truth_doc(
         self, doc_id: str, gt_data: Dict, image: Image.Image
     ) -> Tuple[DoclingDocument, Dict[int, SegmentedPage]]:
-        """Create a DoclingDocument from ground truth data and image file."""
         true_doc = DoclingDocument(name=doc_id)
         img_width, img_height = image.width, image.height
 
-        # Add page with image
         image_ref = ImageRef(
             mimetype="image/png",
             dpi=72,
@@ -131,6 +129,8 @@ class PixparseDatasetBuilder(BaseEvaluationDatasetBuilder):
                 "You must first retrieve the source dataset. Call retrieve_input_dataset()."
             )
 
+        assert isinstance(self.dataset_source, HFSource)
+
         self.target.mkdir(parents=True, exist_ok=True)
         features = Features(
             {
@@ -148,7 +148,7 @@ class PixparseDatasetBuilder(BaseEvaluationDatasetBuilder):
         )
 
         local_parquet_path = hf_hub_download(
-            repo_id=self.dataset_source.repo_id,  # type: ignore
+            repo_id=self.dataset_source.repo_id,
             filename="idl_ocr_dataset.parquet",
             repo_type="dataset",
         )

--- a/docling_eval/dataset_builders/xfund_builder.py
+++ b/docling_eval/dataset_builders/xfund_builder.py
@@ -290,6 +290,16 @@ class XFUNDDatasetBuilder(BaseEvaluationDatasetBuilder):
             )
             cell_by_id[cell_id] = cell
 
+            if cell_text and bbox_instance:
+                seg_page.textline_cells.append(
+                    TextCell(
+                        from_ocr=True,
+                        rect=BoundingRectangle.from_bounding_box(bbox_instance),
+                        text=cell_text,
+                        orig=cell_text,
+                    )
+                )
+
             for word in item.get("words", []):
                 text = word.get("text", None)
                 bbox = word.get("box", None)

--- a/docling_eval/evaluators/ocr/evaluation_models.py
+++ b/docling_eval/evaluators/ocr/evaluation_models.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
 from docling_core.types.doc import BoundingBox
@@ -18,6 +19,11 @@ class _CalculationConstants:
         "–": "-",
         "\xa0": " ",
     }
+
+
+class TextCellUnit(str, Enum):
+    WORD = "word"
+    LINE = "line"
 
 
 class Word(TextCell):

--- a/docling_eval/evaluators/ocr_evaluator.py
+++ b/docling_eval/evaluators/ocr_evaluator.py
@@ -21,6 +21,7 @@ from docling_eval.evaluators.ocr.benchmark_runner import _OcrBenchmark
 from docling_eval.evaluators.ocr.evaluation_models import (
     DocumentEvaluationMetadata,
     OcrDatasetEvaluationResult,
+    TextCellUnit,
     TruePositiveMatch,
     Word,
     WordEvaluationMetadata,
@@ -47,6 +48,7 @@ class OCREvaluator(BaseEvaluator):
         prediction_sources: List[PredictionFormats] = [
             PredictionFormats.DOCLING_DOCUMENT
         ],
+        text_unit: TextCellUnit = TextCellUnit.WORD,
     ) -> None:
         super().__init__(
             intermediate_evaluations_path=intermediate_evaluations_path,
@@ -54,6 +56,7 @@ class OCREvaluator(BaseEvaluator):
             supported_prediction_formats=[PredictionFormats.DOCLING_DOCUMENT],
         )
         self.intermediate_evaluations_path = intermediate_evaluations_path
+        self.text_unit = text_unit
 
     def __call__(
         self,
@@ -72,6 +75,7 @@ class OCREvaluator(BaseEvaluator):
             add_space_for_merged_prediction_words=use_space_for_prediction_merge,
             add_space_for_merged_gt_words=use_space_for_gt_merge,
             aggregation_mode="union",
+            text_unit=self.text_unit,
         )
 
         _log.info("Loading data split '%s' from: '%s'", data_split_name, dataset_path)

--- a/docling_eval/evaluators/ocr_evaluator.py
+++ b/docling_eval/evaluators/ocr_evaluator.py
@@ -56,7 +56,7 @@ class OCREvaluator(BaseEvaluator):
             supported_prediction_formats=[PredictionFormats.DOCLING_DOCUMENT],
         )
         self.intermediate_evaluations_path = intermediate_evaluations_path
-        self.text_unit = text_unit
+        self.text_unit: TextCellUnit = text_unit
 
     def __call__(
         self,

--- a/docling_eval/prediction_providers/aws_prediction_provider.py
+++ b/docling_eval/prediction_providers/aws_prediction_provider.py
@@ -271,6 +271,29 @@ class AWSTextractPredictionProvider(BasePredictionProvider):
                         )
                     )
 
+            elif block["BlockType"] == "LINE" and block.get("Page", 1) == page_no:
+                text_content = block.get("Text", None)
+                geometry = block.get("Geometry", None)
+
+                if text_content is not None and geometry is not None:
+                    bbox = self.extract_bbox_from_geometry(geometry)
+                    bbox_obj = BoundingBox(
+                        l=bbox["l"] * width,
+                        t=bbox["t"] * height,
+                        r=bbox["r"] * width,
+                        b=bbox["b"] * height,
+                        coord_origin=CoordOrigin.TOPLEFT,
+                    )
+
+                    segmented_pages[page_no].textline_cells.append(
+                        TextCell(
+                            rect=BoundingRectangle.from_bounding_box(bbox_obj),
+                            text=text_content,
+                            orig=text_content,
+                            from_ocr=False,
+                        )
+                    )
+
             elif block["BlockType"] == "LAYOUT_TITLE":
                 self._add_title(block, doc, height, page_no, width, blocks_map)
 

--- a/docling_eval/prediction_providers/azure_prediction_provider.py
+++ b/docling_eval/prediction_providers/azure_prediction_provider.py
@@ -183,6 +183,30 @@ class AzureDocIntelligencePredictionProvider(BasePredictionProvider):
                         )
                     )
 
+            for line in page.get("lines", []):
+                polygon = line.get("polygon", None)
+                text_content = line.get("content", None)
+
+                if text_content is not None and polygon is not None:
+                    bbox = self.extract_bbox_from_polygon(polygon)
+                    bbox_obj = BoundingBox(
+                        l=bbox["l"],
+                        t=bbox["t"],
+                        r=bbox["r"],
+                        b=bbox["b"],
+                        coord_origin=CoordOrigin.TOPLEFT,
+                    )
+
+                    segmented_pages[page_no].textline_cells.append(
+                        TextCell(
+                            rect=BoundingRectangle.from_bounding_box(bbox_obj),
+                            text=text_content,
+                            orig=text_content,
+                            # Keeping from_ocr flag False since Azure output doesn't indicate whether the given line is programmatic or OCR
+                            from_ocr=False,
+                        )
+                    )
+
         # Iterate over tables in the response and add to DoclingDocument
         self._add_tables(analyze_result, doc)
 


### PR DESCRIPTION
1. Added textline-level evaluation support, allowing evaluations at both word and line levels.
2. Automatic text unit selection, for benchmarks like XFUND and PixParse-IDL, evaluation now uses textlines, otherwise defaults to words.
3. Textline extraction implemented for hyperscaler prediction providers (AWS, Azure, Google) and integrated into dataset builders (XFUND, FUNSD, PixParse).
4. PixParse-IDL dataset updated to use a HuggingFace hosted, subsampled version with 1,000 images for evaluation.
5. PixParse builder rewritten to load data directly from parquet files via `hf_hub_download` instead of local JSON directories.
6. Updated ground truth generation with proper bounding box scaling and validation for textlines in pixparse.
7. Updated OCREvaluator and BenchmarkRunner to handle both word and line text units with configurable evaluation modes.
