### PR TITLE
feat: implement retry mechanism for dataset downloads to handle rate limits

### DIFF
--- a/docling_eval/dataset_builders/dpbench_builder.py
+++ b/docling_eval/dataset_builders/dpbench_builder.py
@@ -96,6 +96,7 @@ class DPBenchDatasetBuilder(BaseEvaluationDatasetBuilder):
         split: str = "test",
         begin_index: int = 0,
         end_index: int = -1,
+        max_workers: int = 8,
     ):
         """
         Initialize the DPBench dataset builder.
@@ -105,10 +106,13 @@ class DPBenchDatasetBuilder(BaseEvaluationDatasetBuilder):
             split: Dataset split to use
             begin_index: Start index for processing (inclusive)
             end_index: End index for processing (exclusive), -1 means process all
+            max_workers: Number of concurrent downloads (default=8 to avoid rate limits)
         """
         super().__init__(
             name="DPBench",
-            dataset_source=HFSource(repo_id="upstage/dp-bench"),
+            dataset_source=HFSource(
+                repo_id="upstage/dp-bench", max_workers=max_workers
+            ),
             target=target,
             split=split,
             begin_index=begin_index,

--- a/docling_eval/dataset_builders/omnidocbench_builder.py
+++ b/docling_eval/dataset_builders/omnidocbench_builder.py
@@ -96,6 +96,7 @@ class OmniDocBenchDatasetBuilder(BaseEvaluationDatasetBuilder):
         split: str = "test",
         begin_index: int = 0,
         end_index: int = -1,
+        max_workers: int = 8,
     ):
         """
         Initialize the OmniDocBench dataset builder.
@@ -108,7 +109,11 @@ class OmniDocBenchDatasetBuilder(BaseEvaluationDatasetBuilder):
         """
         super().__init__(
             name="OmniDocBench: end-to-end",
-            dataset_source=HFSource(repo_id="opendatalab/OmniDocBench"),
+            dataset_source=HFSource(
+                repo_id="opendatalab/OmniDocBench",
+                max_workers=max_workers,
+                revision="v1_0",
+            ),
             target=target,
             split=split,
             begin_index=begin_index,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "scipy>=1.15.3",
     "scipy-stubs>=1.15.3.0",
     "editdistance>=0.8.1",
+    "tenacity>=9.1.2",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -906,6 +906,7 @@ dependencies = [
     { name = "scipy-stubs", version = "1.15.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy-stubs", version = "1.16.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tabulate" },
+    { name = "tenacity" },
     { name = "torch" },
     { name = "torchmetrics" },
     { name = "tqdm" },
@@ -985,6 +986,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "scipy-stubs", specifier = ">=1.15.3.0" },
     { name = "tabulate", specifier = ">=0.9.0,<0.10.0" },
+    { name = "tenacity", specifier = ">=9.1.2" },
     { name = "torch", specifier = ">=2.5.1,<3.0.0" },
     { name = "torchmetrics", specifier = ">=1.6.0,<2.0.0" },
     { name = "tqdm", specifier = ">=4.67.1,<5.0.0" },
@@ -5083,6 +5085,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* Updated to use the versioned Omnidoc Bench dataset to fix test failures caused by format changes in the original dataset. (https://huggingface.co/datasets/opendatalab/OmniDocBench/tree/main)
* Added exponential backoff to handle Hugging Face rate limiting errors (1000 requests per 5 minutes).
