### PR TITLE
feat: Harmonizing pic classes for cvat to docling conversion

### DIFF
--- a/docling_eval/cvat_tools/cvat_to_docling.py
+++ b/docling_eval/cvat_tools/cvat_to_docling.py
@@ -119,7 +119,7 @@ pic_classes = {
     "LOGO": "logo",
     "OTHER": "other",
     "PERSON": "person",
-    "PICTOGRAM": "pictogram",
+    "PICTOGRAM": "icon",
     "SCREENSHOT": "screenshot",
     "UI_ELEMENT": "ui_element",
 }


### PR DESCRIPTION
Expanded picture classification, harmonizes labels with docling-core, in order to support conversion to DocTags.
Related docling-core PR: https://github.com/docling-project/docling-core/pull/404