### PR TITLE
fix: fix empty prediction handling in markdown evaluator

### DIFF
--- a/docling_eval/evaluators/markdown_text_evaluator.py
+++ b/docling_eval/evaluators/markdown_text_evaluator.py
@@ -156,7 +156,7 @@ class MarkdownTextEvaluator(BaseEvaluator):
             true_md = self._docling_document_to_md(true_doc)
             pred_md = self._get_pred_md(data_record)
 
-            if pred_md is None:
+            if not pred_md:
                 _log.error("There is no markdown prediction for doc_id=%s", doc_id)
                 rejected_samples[EvaluationRejectionType.MISSING_PREDICTION] += 1
                 continue


### PR DESCRIPTION
Empty `""` predictions otherwise lead to an `UnboundLocalError` for `ntlk_scores` [here](https://github.com/docling-project/docling-eval/blob/5084a4d675d6cf2478b08b72fd3fbc9949c2de6d/docling_eval/evaluators/markdown_text_evaluator.py#L171).