### PR TITLE
fix(dpbench): normalize coordinates for upstream breaking change

### DIFF
--- a/docling_eval/dataset_builders/dpbench_builder.py
+++ b/docling_eval/dataset_builders/dpbench_builder.py
@@ -151,6 +151,17 @@ class DPBenchDatasetBuilder(BaseEvaluationDatasetBuilder):
             min_y = min(min_y, coor["y"])
             max_y = max(max_y, coor["y"])
 
+        # upstage/dp-bench commit 24702c6 changed reference.json coords from
+        # normalized [0,1] to absolute image pixels. Detect and normalize so
+        # crop_bounding_box receives consistent [0,1]-scaled page units.
+        if max_x > 1.0 or max_y > 1.0:
+            img_w = float(page_image.width)
+            img_h = float(page_image.height)
+            min_x = min_x / img_w
+            max_x = max_x / img_w
+            min_y = min_y / img_h
+            max_y = max_y / img_h
+
         text = annots["content"]["text"].replace("\n", " ")
         html = annots["content"]["html"]
 

--- a/docling_eval/evaluators/ocr_evaluator.py
+++ b/docling_eval/evaluators/ocr_evaluator.py
@@ -236,7 +236,7 @@ class OCREvaluator(BaseEvaluator):
                 metadata_path = (
                     evaluation_metadata_output_path / f"{document_id}_metadata.json"
                 )
-                with open(metadata_path, "w") as f:
+                with open(metadata_path, "w", encoding="utf-8") as f:
                     f.write(metadata.model_dump_json(indent=2))
             processed_item_count += 1
 


### PR DESCRIPTION
The `upstage/dp-bench` dataset was updated on ~April 22 2026 (commit `24702c6`, "Sync evaluation codes and leaderboard with the latest version") 
commit: https://huggingface.co/datasets/upstage/dp-bench/commit/24702c61a2fb13325534be664653bc6e60250d13#d2h-687070
raw diff: https://huggingface.co/datasets/upstage/dp-bench/commit/24702c61a2fb13325534be664653bc6e60250d13.diff?file=dataset%2Freference.json

and silently changed reference.json coordinate format from normalized [0–1] to absolute image pixel values. 

This causes `_update_gt_doc` to multiply pixel coordinates by page_width (~595 pts), and crop_bounding_box to multiply again by scale_x, producing bounding boxes of ~760 billion pixels and a PIL.Image.DecompressionBombError.

The fix added in the PR is to detect absolute pixel coordinates (max_x > 1.0 or max_y > 1.0) and normalize by page_image.width / height before the existing scaling logic. The fix is backward-compatible, datasets using normalized coords pass through unchanged.